### PR TITLE
API support for adding player lists, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+
+*.swp
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+Installing
+==========
+
+Using a [Virtualenv](https://virtualenv.pypa.io/en/latest/) is recommended.
+
+This assumes MySQL as a backend, so you'll need `mysql_config` installed.
+Consult your OS documentation for how to do that.  If you're using a
+different SQL backend, modify `requirements.txt` to use the appropriate
+Python bindings.
+
+    virtualenv ~/venv/xwlists
+    . ~/venv/xwlists/bin/activate
+    pip install -r requirements.txt
+
+Initializing the Database
+=========================
+
+    mysql < dbs/prod.sql
+
+Running the App
+===============
+
+In development mode, so you can see meaningful error messages:
+
+    LOCAL_DB_URL='mysql://localhost/sozin$lists' python xwlists.py dev

--- a/api.py
+++ b/api.py
@@ -628,7 +628,7 @@ class TourneyToJsonConverter:
                 resref[PLAYER2_POINTS] = result.list2_score
                 resref[RESULT] = result.get_result_for_json()
 
-        return json.dumps(ret)
+        return ret
 
 
 
@@ -734,7 +734,7 @@ class TournamentAPI(restful.Resource):
 
         pm.db_connector.get_session().commit()
 
-        return TourneyToJsonConverter().convert(t)
+        return jsonify(TourneyToJsonConverter().convert(t))
 
     def delete(self, tourney_id):
         pm = PersistenceManager(myapp.db_connector)

--- a/api.py
+++ b/api.py
@@ -10,9 +10,6 @@ WIN = 'win'
 FORMAT = 'format'
 __author__ = 'lhayhurst'
 
-import logging
-logger = logging.getLogger(__name__)
-
 import uuid
 from xwingmetadata import sets_and_expansions
 import json

--- a/api.py
+++ b/api.py
@@ -817,6 +817,7 @@ class TournamentTokenAPI(restful.Resource):
     '''
         Accepts POST { "email": "email@used.to.create" }
         If email is valid, returns dict of api_token: api_token
+        Creates api_token if needed.
     '''
     def post(self, tourney_id):
         helper = TournamentApiHelper()
@@ -834,5 +835,9 @@ class TournamentTokenAPI(restful.Resource):
 
         if email != tourney.email:
             return helper.bail("incorrect email for tourney {}".format(tourney_id), 404)
+
+        if tourney.api_token is None:
+            tourney.api_token = str(uuid.uuid4())
+            pm.db_connector.get_session().commit()
 
         return jsonify({"api_token": tourney.api_token})

--- a/api.py
+++ b/api.py
@@ -479,9 +479,8 @@ class PlayerAPI(restful.Resource):
         if XWS in json_data:
             dirty = True
             try:
-                new_tourney_list = TourneyList(tourney_id=tourney_id, player_id=player_id)
-                player.tourney_lists.append(new_tourney_list)
-                XWSToJuggler(json_data[XWS]).convert(pm, new_tourney_list)
+                tourney_list = player.tourney_lists[-1]
+                XWSToJuggler(json_data[XWS]).convert(pm, tourney_list)
             except:
                 pm.db_connector.get_session().rollback()
                 return helper.bail('Could not add list via XWS', 400)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 BeautifulSoup==3.2.1
 Flask==0.10.1
+Flask-Cors==2.0.0
 Flask-Mail==0.9.1
 Flask-RESTful==0.3.2
 Jinja2==2.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+BeautifulSoup==3.2.1
+Flask==0.10.1
+Flask-Mail==0.9.1
+Flask-RESTful==0.3.2
+Jinja2==2.7.3
+MarkupSafe==0.23
+MySQL-python==1.2.5
+SQLAlchemy==0.9.9
+Werkzeug==0.10.4
+aniso8601==0.92
+argparse==1.2.1
+blinker==1.3
+itsdangerous==0.24
+python-dateutil==2.4.2
+pytz==2015.2
+six==1.9.0
+wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ aniso8601==0.92
 argparse==1.2.1
 blinker==1.3
 itsdangerous==0.24
+nose==1.3.4
 python-dateutil==2.4.2
 pytz==2015.2
+requests==2.6.0
 six==1.9.0
 wsgiref==0.1.2

--- a/xwlists.py
+++ b/xwlists.py
@@ -21,9 +21,11 @@ from rollup import Rollup
 import xwingmetadata
 from xws import VoidStateXWSFetcher, XWSToJuggler, YASBFetcher, FabFetcher
 from flask.ext import restful
+from flask_cors import CORS
 
 
 app =  myapp.create_app()
+cors = CORS(app, resources={r"/api/*": {"origins": "*"}})
 UPLOAD_FOLDER = "static/tourneys"
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 ALLOWED_EXTENSIONS = set( ['png', 'jpg', 'jpeg', 'gif', 'html', 'json'])

--- a/xwlists.py
+++ b/xwlists.py
@@ -9,7 +9,7 @@ from flask.ext.mail import Mail, Message
 import sys
 from sqlalchemy import func
 from werkzeug.utils import secure_filename
-from api import TournamentsAPI, TournamentAPI, PlayersAPI, PlayerAPI, TournamentSearchAPI
+from api import TournamentsAPI, TournamentAPI, PlayersAPI, PlayerAPI, TournamentSearchAPI, TournamentTokenAPI
 
 from cryodex import Cryodex
 from dataeditor import RankingEditor
@@ -66,6 +66,7 @@ api.add_resource(PlayersAPI, '/api/v1/tournament/<int:tourney_id>/players' )
 api.add_resource(PlayerAPI, '/api/v1/tournament/<int:tourney_id>/player/<int:player_id>' )
 
 api.add_resource(TournamentSearchAPI, '/api/v1/search/tournaments')
+api.add_resource(TournamentTokenAPI, '/api/v1/tournament/<int:tourney_id>/token')
 
 
 @app.before_request

--- a/xwlists.py
+++ b/xwlists.py
@@ -9,7 +9,7 @@ from flask.ext.mail import Mail, Message
 import sys
 from sqlalchemy import func
 from werkzeug.utils import secure_filename
-from api import TournamentsAPI, TournamentAPI, PlayersAPI, PlayerAPI
+from api import TournamentsAPI, TournamentAPI, PlayersAPI, PlayerAPI, TournamentSearchAPI
 
 from cryodex import Cryodex
 from dataeditor import RankingEditor
@@ -64,6 +64,8 @@ api.add_resource(TournamentsAPI, '/api/v1/tournaments')
 api.add_resource(TournamentAPI, '/api/v1/tournament/<int:tourney_id>' )
 api.add_resource(PlayersAPI, '/api/v1/tournament/<int:tourney_id>/players' )
 api.add_resource(PlayerAPI, '/api/v1/tournament/<int:tourney_id>/player/<int:player_id>' )
+
+api.add_resource(TournamentSearchAPI, '/api/v1/search/tournaments')
 
 
 @app.before_request


### PR DESCRIPTION
I want to add some functionality to my YASB XWS backend to facilitate adding lists to List Juggler.

Added endpoints for:

- Searching for tournaments by name/venue name
- Fetching API token, authenticated by TO email (creates API token if one does not already exist)

Updated endpoints:

- Player can be added via PUT, including XWS
- XWS can be included in JSON data POSTed to players endpoint

Fixed the tournament GET endpoint, which was returning a JSONified string of a JSONified object.

This supersedes my previous pull request (includes documentation, requirements.txt).